### PR TITLE
Store secrets in vault

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -19,6 +19,7 @@ RUN apt-get update && \
         curl \
         vim \
         less \
+        jq \
         unzip \
         file && \
     rm -f /bin/sh && ln -s /bin/bash /bin/sh

--- a/backends/client.go
+++ b/backends/client.go
@@ -16,6 +16,7 @@ type EncryptorClient interface {
 	GetClearText(keyName string, cipherText string) (string, error)
 	Sign(keyName string, text string) (string, error)
 	VerifySignature(keyName string, signature string, message string) (bool, error)
+	Delete(keyName, cipherText string) error
 }
 
 // New returns an encrytion client of a specific type

--- a/backends/localkey/client.go
+++ b/backends/localkey/client.go
@@ -81,6 +81,11 @@ func (l *Client) VerifySignature(keyName, signature, message string) (bool, erro
 	return aesutils.VerifySignature(key, signature, message)
 }
 
+// Delete No op nothing stored
+func (l *Client) Delete(keyName, cipherText string) error {
+	return nil
+}
+
 func testIsDir(keyPath string) (bool, error) {
 	result := false
 

--- a/backends/none/client.go
+++ b/backends/none/client.go
@@ -31,3 +31,8 @@ func (n *Client) VerifySignature(keyName, signature, message string) (bool, erro
 	hashBytes := md5.Sum([]byte(message))
 	return signature == hex.EncodeToString(hashBytes[:]), nil
 }
+
+// Delete No Op, not stored.
+func (n *Client) Delete(keyName, cipherText string) error {
+	return nil
+}

--- a/backends/vault/client.go
+++ b/backends/vault/client.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"strings"
@@ -13,17 +14,27 @@ import (
 
 // Client is the struct that implements the backend interface
 type Client struct {
-	url   string
-	token string
+	url        string
+	token      string
+	storageDir string
 }
 
 // NewClient returns a Client type that is ready to interact
 // with vault
 func NewClient(url, token string) (*Client, error) {
-	return &Client{
+	var err error
+
+	client := &Client{
 		url:   url,
 		token: token,
-	}, nil
+	}
+
+	client.storageDir, err = client.getStorageDir()
+	if err != nil {
+		return client, err
+	}
+
+	return client, nil
 }
 
 // GetEncryptedText None Client just returns the clearText
@@ -41,6 +52,9 @@ func (v *Client) GetEncryptedText(keyName, clearText string) (string, error) {
 	}
 
 	if cipherText, ok := secret.Data["ciphertext"].(string); ok && cipherText != "" {
+		if v.storageDir != "" {
+			cipherText, err = v.storeSecretInVault(cipherText)
+		}
 		return cipherText, nil
 	}
 
@@ -49,7 +63,15 @@ func (v *Client) GetEncryptedText(keyName, clearText string) (string, error) {
 
 // GetClearText  None Client just returns the cipherText
 func (v *Client) GetClearText(keyName, cipherText string) (string, error) {
+	var err error
 	decryptPath := fmt.Sprintf("/transit/decrypt/%s", keyName)
+
+	if v.storageDir != "" {
+		cipherText, err = v.retrieveSecretFromVault(cipherText)
+		if err != nil {
+			return "", err
+		}
+	}
 
 	secret, err := v.writeToVault(decryptPath, map[string]interface{}{"ciphertext": cipherText})
 	if err != nil {
@@ -134,6 +156,23 @@ func (v *Client) writeToVault(path string, data map[string]interface{}) (*api.Se
 	return vaultClient.Logical().Write(path, data)
 }
 
+func (v *Client) getStorageDir() (string, error) {
+	tokenLookupData := map[string]interface{}{
+		"token": v.token,
+	}
+
+	secret, err := v.writeToVault("/auth/token/lookup", tokenLookupData)
+	if err != nil {
+		return "", err
+	}
+
+	if storageDir, ok := secret.Data["meta"].(map[string]interface{})["storage_dir"]; ok {
+		return storageDir.(string), nil
+	}
+
+	return "", nil
+}
+
 func (v *Client) getVaultClient() (*api.Client, error) {
 	config := api.DefaultConfig()
 	config.Address = v.url
@@ -167,4 +206,41 @@ func testVaultTransitKeyExists(vaultCli *api.Client, keyName string) (bool, erro
 
 func formatSignatureString(nonce, data string) (string, error) {
 	return base64.StdEncoding.EncodeToString([]byte(nonce + ":" + data)), nil
+}
+
+func (v *Client) storeSecretInVault(cipherText string) (string, error) {
+	// write secret to path in Vault
+	hash := sha256.New()
+	hash.Write([]byte(cipherText))
+
+	path := fmt.Sprintf("%s/v1-secrets/%x", v.storageDir, string(hash.Sum(nil)))
+
+	_, err := v.writeToVault(path, map[string]interface{}{
+		"cipherText": cipherText,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// we will just pass back the location
+	return path, nil
+}
+
+func (v *Client) retrieveSecretFromVault(path string) (string, error) {
+	cli, err := v.getVaultClient()
+	if err != nil {
+		return "", err
+	}
+
+	secret, err := cli.Logical().Read(path)
+	if err != nil {
+		return "", err
+	}
+
+	logrus.Debugf("%#v", secret)
+	if text, ok := secret.Data["cipherText"]; ok {
+		return text.(string), nil
+	}
+
+	return "", fmt.Errorf("No CipherText at this location")
 }

--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -1,7 +1,7 @@
 cattle==0.5.1
 requests
 pycrypto==2.6.1
-cryptography==1.7.2
+hvac[parser]
 
 flake8
 pytest==2.3.5

--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -9,17 +9,49 @@ echo "A374A26A71490437AA024E4FADD5B49" > /etc/ssl/private/alt_test_key
 
 export VAULT_ROOT_TOKEN_ID="testing"
 
-export VAULT_TOKEN=${VAULT_ROOT_TOKEN_ID}
-export VAULT_ADDR=http://127.0.0.1:8200
+#export VAULT_TOKEN=${VAULT_ROOT_TOKEN_ID}
+#export VAULT_ADDR=http://127.0.0.1:8200
 
 /usr/bin/vault server -dev -dev-root-token-id=${VAULT_ROOT_TOKEN_ID} &
-sleep 10
-/usr/bin/vault mount transit
-/usr/bin/vault mounts
-/usr/bin/vault write -f transit/keys/rancher
-/usr/bin/vault read transit/keys/rancher
+sleep 3
 
-./bin/secrets-api -d server --enc-key-path /etc/ssl/private &
+/usr/bin/vault server -dev -dev-root-token-id=${VAULT_ROOT_TOKEN_ID} -dev-listen-address 0.0.0.0:18200 &
+sleep 3
+
+wire_vault()
+{
+    export VAULT_ADDR="${1}"
+    export VAULT_TOKEN=${VAULT_ROOT_TOKEN_ID}
+
+    /usr/bin/vault mount transit
+    /usr/bin/vault mounts
+    /usr/bin/vault write -f transit/keys/rancher
+    /usr/bin/vault read transit/keys/rancher
+}
+
+get_token()
+{
+    export VAULT_ADDR="${1}"
+    export VAULT_TOKEN=${VAULT_ROOT_TOKEN_ID}
+
+    if [ "${2}" = "true" ]; then
+        export OPTS=-metadata="storage_dir=/secret/rancher"
+    fi
+
+    echo $(/usr/bin/vault token-create ${OPTS} -format=json| jq -r '.auth.client_token')
+}
+
+# Normal ephemeral storage
+wire_vault "http://127.0.0.1:8200"
+TOKEN1=$(get_token "http://127.0.0.1:8200")
+echo ./bin/secrets-api -d server --enc-key-path /etc/ssl/private --vault-url http://127.0.0.1:8200 --vault-token ${TOKEN1}
+./bin/secrets-api -d server --enc-key-path /etc/ssl/private --vault-url http://127.0.0.1:8200 --vault-token ${TOKEN1} &
+
+# Makes use of vault storage
+wire_vault "http://127.0.0.1:18200"
+TOKEN2=$(get_token "http://127.0.0.1:18200" "true")
+echo ./bin/secrets-api -d server --enc-key-path /etc/ssl/private --vault-url http://127.0.0.1:18200 --vault-token ${TOKEN2} --listen-address 127.0.0.1:18181
+./bin/secrets-api -d server --enc-key-path /etc/ssl/private --vault-url http://127.0.0.1:18200 --vault-token ${TOKEN2} --listen-address 127.0.0.1:18181 &
 
 cd integration
 python --version

--- a/secrets/bulk.go
+++ b/secrets/bulk.go
@@ -49,3 +49,15 @@ func (s *BulkSecret) Encrypt() error {
 	}
 	return nil
 }
+
+func (s *BulkSecret) Delete() error {
+	for idx, secret := range s.Data {
+		err := secret.Delete()
+		if err != nil {
+			logrus.Error(err)
+			return err
+		}
+		s.Data[idx] = secret
+	}
+	return nil
+}

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -50,6 +50,15 @@ func (s *Secret) Rewrap() error {
 	return s.clean(s.rewrap)
 }
 
+func (s *Secret) Delete() error {
+	backend, err := backends.New(s.Backend)
+	if err != nil {
+		return err
+	}
+
+	return backend.Delete(s.KeyName, s.CipherText)
+}
+
 func (s *Secret) encrypt() error {
 	if _, err := base64.StdEncoding.DecodeString(s.ClearText); err != nil {
 		s.ClearText = base64.StdEncoding.EncodeToString([]byte(s.ClearText))

--- a/service/router.go
+++ b/service/router.go
@@ -61,6 +61,14 @@ func NewRouter() *mux.Router {
 			Input:  "bulkSecret",
 			Output: "bulkSecret",
 		},
+		"purge": {
+			Input:  "secret",
+			Output: "secret",
+		},
+		"purge?action=bulk": {
+			Input:  "bulkSecret",
+			Output: "bulkSecret",
+		},
 	}
 
 	router := mux.NewRouter().StrictSlash(false)
@@ -95,6 +103,15 @@ func NewRouter() *mux.Router {
 		Handler(f(schemas, BulkRewrapSecret))
 
 	router.Methods("POST").Path("/v1-secrets/secrets/rewrap").Handler(f(schemas, RewrapSecret))
+
+	router.Methods("POST").
+		Path("/v1-secrets/secrets/delete").
+		Queries("action", "bulk").
+		Handler(f(schemas, BulkDeleteSecret))
+
+	router.Methods("POST").
+		Path("/v1-secrets/secrets/delete").
+		Handler(f(schemas, DeleteSecret))
 
 	// These just loop back to themselves in the schemas
 	router.Methods("GET").Path("/v1-secrets/secrets/create").Handler(f(schemas, ListSecrets))


### PR DESCRIPTION
This PR adds the ability to store and retrieve data from a vault storage backend.

In addition to using the Vault transit backend, the api will store the encrypted value inside vault, and return the path in vault to find the secret back to Rancher for storage in the database.

This update also includes a new `purge` action to remove the secrets when delete is called.
